### PR TITLE
Fixing Nav-Bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,15 @@
     <script src="javascripts/jquery.nav.js"></script>
     <script src="javascripts/jquery.parallax.js"></script>
     <script type="text/javascript">
+      //JQuery seems to have a bug in newes Firefox- an Chromium-Browsers. See: http://bugs.jquery.com/ticket/3046
+      //This is the temporary solution:
+      var height_ = jQuery.fn.height;
+      jQuery.fn.height = function() {
+          if ( this[0] == window)
+              return window.innerHeight;
+          else return height_.apply(this,arguments);
+      };
+    
       $(document).ready(function() {
         $('#nav').onePageNav({
           currentClass: 'active',


### PR DESCRIPTION
Die Navigationsbar markiert immer das falsche Element. Das liegt daran, dass $(window).height() einen falschen Wert liefert.
Das Problem trat wohl schonmal bei Jquery+Opera-Browser auf: http://bugs.jquery.com/ticket/3046
Falls das Problem nicht bald von JQuery behoben wird, kann man den vorläufigen Bugfix, welcher im JQuery-bugtracker vorgeschlagen wurde, mit diesem Pull-Request einbauen.
